### PR TITLE
Fix empty cart display style in checkout handler

### DIFF
--- a/shopScript.js
+++ b/shopScript.js
@@ -246,10 +246,10 @@ cartButton.addEventListener("click", function () {
             // Perform checkout functionality
             window.location.href = "checkout.html";
           } else {
-            emptyCartDivEffect.display = "block";
+            emptyCartDivEffect.style.display = "block";
             emptyCartDivEffect.style.animation = "shake 1.5s";
             cartItemsContainer.appendChild(emptyCartDivEffect);
-            setTimeout ( function(){emptyCartDivEffect.display = "none";}, 3000);
+            setTimeout ( function(){emptyCartDivEffect.style.display = "none";}, 3000);
             }
         });
 }


### PR DESCRIPTION
## Summary
- Correct `emptyCartDivEffect` display handling in checkout button logic

## Testing
- `node -c shopScript.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c168b858c08327af45719004479a27